### PR TITLE
Fix duplicated barcode data

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -24,7 +24,7 @@ GIT
 PATH
   remote: .
   specs:
-    lims-emailnotifier-app (0.0.0.0.4)
+    lims-emailnotifier-app (0.0.0.0.5)
       bunny (= 0.9.0.pre10)
       rest-client
 

--- a/lib/lims-emailnotifier-app/emailer.rb
+++ b/lib/lims-emailnotifier-app/emailer.rb
@@ -17,7 +17,7 @@ module Lims
       attribute :log, Object, :required => true, :writer => :private, :reader => :private
 
       ORDER_PAYLOAD = "order"
-      ORDER_ROUTING_KEY_PATTERN = /.*\..*\.order\..*/
+      ORDER_ROUTING_KEY_PATTERN = /^[^\.]*\.[^\.]*\.order\.[^\.]*$/
 
       # @param [Hash] amqp_settings
       # @param [Hash] email_opts

--- a/lib/lims-emailnotifier-app/order_requester.rb
+++ b/lib/lims-emailnotifier-app/order_requester.rb
@@ -50,7 +50,7 @@ module Lims::EmailNotifierApp
           item_uuids << item.fetch("uuid")
         end
       end
-      item_uuids.flatten
+      item_uuids.flatten.uniq!
     end
 
     # Gets a specific order item by its uuid

--- a/lib/lims-emailnotifier-app/version.rb
+++ b/lib/lims-emailnotifier-app/version.rb
@@ -1,5 +1,5 @@
 module Lims
   module EmailNotifierApp
-    VERSION = "0.0.0.0.4"
+    VERSION = "0.0.0.0.5"
   end
 end


### PR DESCRIPTION
When an order item has appeared under more role, the e-mail notifier has listed its barcode data more then once. It has been fixed.
